### PR TITLE
Merge in the fixes to make the re-org actually work

### DIFF
--- a/deployments/cf-aws-tiny.yml
+++ b/deployments/cf-aws-tiny.yml
@@ -14,9 +14,9 @@ stemcells:
 templates:
   - cf/cf-deployment.yml
   - tiny/cf-tiny-dev.yml
-  - tiny/cf-test-errands.yml
   - cf/cf-properties.yml
   - cf/cf-infrastructure-aws.yml
+# - cf-test-errands.yml
   - cf-properties.yml
   - parallel.yml
   - tiny/cf-aws.yml

--- a/templates/cf-test-errands.yml
+++ b/templates/cf-test-errands.yml
@@ -1,5 +1,6 @@
 meta:
   secrets: (( merge ))
+  admin_secret: (( merge ))
   smoke_tests:
     org: (( merge || "smoke-tests" ))
     space: (( merge || "smoke-tests" ))
@@ -18,7 +19,7 @@ properties:
     api:  (( "api." properties.domain ))
     apps_domain: (( properties.domain ))
     admin_user: admin
-    admin_password: "CF_ADMIN_PASS"
+    admin_password: (( meta.admin_secret ))
     skip_ssl_validation: true
     nodes: 1
 
@@ -26,7 +27,7 @@ properties:
     api:  (( "api." properties.domain ))
     apps_domain: (( properties.domain ))
     user: admin
-    password: "CF_ADMIN_PASS"
+    password: (( meta.admin_secret ))
     org: (( meta.smoke_tests.org ))
     space: (( meta.smoke_tests.org ))
     skip_ssl_validation: true

--- a/templates/cf-use-haproxy.yml
+++ b/templates/cf-use-haproxy.yml
@@ -3,13 +3,14 @@ meta:
   security_groups: (( merge ))
   floating_static_ips: (( merge ))
   availability_zones: (( merge ))
+  domain: (( merge ))
   ha_proxy:
     ssl_pem: (( merge || defaults.ha_proxy.ssl_pem ))
   subnet_ids:
     lb1: (( merge ))
 
 properties:
-  domain: (( jobs.ha_proxy_z1.networks.floating.static_ips.[0] ".xip.io" ))
+  domain: (( domain ))
 
 networks:
   - <<: (( merge ))

--- a/templates/tiny/cf-tiny-dev.yml
+++ b/templates/tiny/cf-tiny-dev.yml
@@ -40,14 +40,18 @@ meta:
   - name: metron_agent
     release: (( meta.release.name ))
 
+  ha_proxy_templates:
+  - name: metron_agent
+    release: (( meta.release.name ))
+  - name: haproxy
+    release: (( meta.release.name ))
+
   api_templates:
   - name: gorouter
     release: (( meta.release.name ))
   - name: cloud_controller_ng
     release: (( meta.release.name ))
   - name: metron_agent
-    release: (( meta.release.name ))
-  - name: haproxy
     release: (( meta.release.name ))
   - name: nfs_mounter
     release: (( meta.release.name ))
@@ -106,24 +110,37 @@ jobs:
       metron_agent:
         zone: z1
 
-  - name: api
+  - name: haproxy
     instances: 1
-    templates: (( merge || meta.api_templates ))
-    resource_pool: medium_z2
+    templates: (( merge || meta.ha_proxy_templates ))
+    resource_pool: small_z1
     networks:
       - name: floating
         static_ips: (( meta.floating_static_ips ))
-      - name: cf2
+      - name: lb1
         default: [dns, gateway]
         static_ips: (( static_ips(1) ))
     properties:
-      networks: (( meta.networks.z2 ))
-      router:
-        port: 81 # haproxy needs 80
+      networks: (( meta.networks.z1 ))
       ha_proxy:
         ssl_pem: (( meta.ha_proxy.ssl_pem ))
       metron_agent:
-        zone: z2
+        zone: z1
+
+  - name: api
+    instances: 1
+    templates: (( merge || meta.api_templates ))
+    resource_pool: medium_z1
+    networks:
+      - name: cf1
+        default: [dns, gateway]
+        static_ips: (( static_ips(1) ))
+    properties:
+      networks: (( meta.networks.z1 ))
+      ha_proxy:
+        ssl_pem: (( meta.ha_proxy.ssl_pem ))
+      metron_agent:
+        zone: z1
 
   - name: services
     instances: 1
@@ -317,8 +334,8 @@ properties:
 
   router:
     servers:
-      z1: []
-      z2: (( jobs.api.networks.cf2.static_ips ))
+      z1: (( jobs.api.networks.cf1.static_ips ))
+      z2: []
     requested_route_registration_interval_in_seconds: 20
     status:
       user: (( merge ))

--- a/templates/tiny/cf-use-haproxy.yml
+++ b/templates/tiny/cf-use-haproxy.yml
@@ -1,4 +1,11 @@
 meta:
+  ipmask: (( merge ))
+  security_groups: (( merge ))
+  subnet_ids: 
+    cf1: (( merge ))
+    cf2: (( merge ))
+    lb1: (( merge ))
+  availability_zones: (( merge ))
   floating_static_ips: (( merge ))
   ha_proxy:
     ssl_pem: (( merge || defaults.ha_proxy.ssl_pem ))
@@ -11,6 +18,29 @@ resource_pools:
   - name: router_z2
     cloud_properties:
       elbs: ~
+
+networks:
+  - <<: (( merge ))
+  - name: lb1
+    type: manual
+    subnets:
+      - range: (( meta.ipmask ".2.0/24" ))
+        name: default_unused
+        reserved:
+          - (( meta.ipmask ".2.2 - " meta.ipmask ".2.5" ))
+        static:
+          - (( meta.ipmask ".2.10 - " meta.ipmask ".2.100" ))
+        gateway: (( meta.ipmask ".2.1" ))
+        dns:
+          - (( meta.ipmask ".0.2" ))
+        cloud_properties:
+          security_groups:
+            - (( meta.security_groups ))
+          subnet: (( meta.subnet_ids.lb1 ))
+          availability_zone: (( meta.availability_zones.lb1 ))
+  - name: floating
+    type: vip
+    cloud_properties: {}
 
 properties:
   login:


### PR DESCRIPTION
The main fix is to split out haproxy into a separate VM (small by default),
so that it can live on the loadbalancer network (and thus have internet access).
The rest is small fixes to cf-test-errands, and commenting it out by default to
keep the total number of running VMs the same.