### PR TITLE
Made allowed_services_network_range default to a string vs array

### DIFF
--- a/deployments/cf-aws-large.yml
+++ b/deployments/cf-aws-large.yml
@@ -49,8 +49,7 @@ meta:
   zones:
     z1: CF_SUBNET1_AZ
     z2: CF_SUBNET2_AZ
-  allowed_services_network_range:
-    - 10.10.5.0 - 10.255.255.255
+  allowed_services_network_range: 10.10.5.0 - 10.255.255.255
   floating_static_ips:
     - CF_ELASTIC_IP
   networks:

--- a/deployments/cf-aws-tiny.yml
+++ b/deployments/cf-aws-tiny.yml
@@ -45,8 +45,7 @@ meta:
   zones:
     z1: CF_SUBNET1_AZ
     z2: CF_SUBNET2_AZ
-  allowed_services_network_range:
-    - 10.10.5.0 - 10.255.255.255
+  allowed_services_network_range: 10.10.5.0 - 10.255.255.255
   floating_static_ips:
     - CF_ELASTIC_IP
   networks:

--- a/deployments/cf-openstack-tiny.yml
+++ b/deployments/cf-openstack-tiny.yml
@@ -41,8 +41,7 @@ meta:
   zones:
     z1: CF_SUBNET1_AZ
     z2: CF_SUBNET2_AZ
-  allowed_services_network_range:
-    - 192.168.5.0 - 192.168.255.255
+  allowed_services_network_range: 192.168.5.0 - 192.168.255.255
   floating_static_ips:
     - CF_ELASTIC_IP
   networks:


### PR DESCRIPTION
With allowed_services_network_range as an array, the security_group_definitions object ended up looking like this:
```
    security_group_definitions:
    - name: public_networks
      rules:
      - destination: 0.0.0.0-9.255.255.255
        protocol: all
      - destination: 11.0.0.0-169.253.255.255
        protocol: all
      - destination: 169.255.0.0-172.15.255.255
        protocol: all
      - destination: 172.32.0.0-192.167.255.255
        protocol: all
      - destination: 192.169.0.0-255.255.255.255
        protocol: all
    - name: dns
      rules:
      - destination: 0.0.0.0/0
        ports: "53"
        protocol: tcp
      - destination: 0.0.0.0/0
        ports: "53"
        protocol: udp
    - name: services_network
      rules:
      - destination:
        - 10.10.5.0 - 10.255.255.255
        protocol: all
```
Geoff sucks

The last rule with an array as a destination value freaked out the cloud_controller_clock service. I'm not sure if this is the right fix, or if something else should be done to translate the allowed_services_network_range array into correct rules for the cloud_controller_clock service. @rkoster , can you take a look and let me know?