### PR TITLE
Secure proxy

### DIFF
--- a/deployments/cf-aws-tiny.yml
+++ b/deployments/cf-aws-tiny.yml
@@ -39,6 +39,7 @@ meta:
     z2: CF_SUBNET2_AZ
 
   ha_proxy:
+    <<: (( merge ))
     internal_only_domains:
     - PRIVATE_DOMAIN_PLACEHOLDER
 

--- a/deployments/cf-aws-tiny.yml
+++ b/deployments/cf-aws-tiny.yml
@@ -6,6 +6,9 @@ releases:
   - name: cf
     version: 210 # DEFAULT_CF_RELEASE_VERSION
     git: https://github.com/cloudfoundry/cf-release.git
+  - name: cf-haproxy
+    version: 1 # DEFAULT_CFHAPROXY_RELEASE_VERSION
+    git: https://github.com/cloudfoundry-community/cf-haproxy-boshrelease.git
 
 templates:
   - cf/cf-deployment.yml
@@ -34,6 +37,11 @@ meta:
   zones:
     z1: CF_SUBNET1_AZ
     z2: CF_SUBNET2_AZ
+
+  ha_proxy:
+    internal_only_domains:
+    - PRIVATE_DOMAIN_PLACEHOLDER
+
   allowed_services_network_range: 10.10.5.0 - 10.255.255.255
   floating_static_ips:
     - CF_ELASTIC_IP
@@ -54,8 +62,11 @@ meta:
       net_id: LB_SUBNET1
   environment: cf-aws-tiny
   instances:
+    # Load balancers
+    private_haproxy_z1: 1 # MARKER_FOR_PROVISION
+    public_haproxy_z1:  1 # MARKER_FOR_PROVISION
+
     # Primary AZ nodes
-    haproxy_z1:   1 # MARKER_FOR_PROVISION
     backbone_z1:  1 # MARKER_FOR_PROVISION
     api_z1:       1 # MARKER_FOR_PROVISION
     services_z1:  1 # MARKER_FOR_PROVISION

--- a/deployments/cf-aws-tiny.yml
+++ b/deployments/cf-aws-tiny.yml
@@ -39,7 +39,6 @@ meta:
     z2: CF_SUBNET2_AZ
 
   ha_proxy:
-    <<: (( merge ))
     internal_only_domains:
     - PRIVATE_DOMAIN_PLACEHOLDER
 

--- a/deployments/cf-openstack-tiny.yml
+++ b/deployments/cf-openstack-tiny.yml
@@ -6,6 +6,9 @@ releases:
   - name: cf
     version: 210 # DEFAULT_CF_RELEASE_VERSION
     git: https://github.com/cloudfoundry/cf-release.git
+  - name: cf-haproxy
+    version: 1 # DEFAULT_CFHAPROXY_RELEASE_VERSION
+    git: https://github.com/cloudfoundry-community/cf-haproxy-boshrelease.git
 
 stemcells:
   - name: bosh-openstack-kvm-ubuntu-trusty-go_agent
@@ -45,6 +48,11 @@ meta:
   zones:
     z1: CF_SUBNET1_AZ
     z2: CF_SUBNET2_AZ
+
+  ha_proxy:
+    internal_only_domains:
+    - PRIVATE_DOMAIN_PLACEHOLDER
+
   allowed_services_network_range: 192.168.5.0 - 192.168.255.255
   floating_static_ips:
     - CF_ELASTIC_IP
@@ -66,8 +74,11 @@ meta:
       net_id: LB_SUBNET1
   environment: cf-openstack-tiny
   instances:
+    # Load balancers
+    private_haproxy_z1: 1 # MARKER_FOR_PROVISION
+    public_haproxy_z1:  1 # MARKER_FOR_PROVISION
+
     # Primary AZ nodes
-    haproxy_z1:   1 # MARKER_FOR_PROVISION
     backbone_z1:  1 # MARKER_FOR_PROVISION
     api_z1:       1 # MARKER_FOR_PROVISION
     services_z1:  1 # MARKER_FOR_PROVISION

--- a/templates/tiny/cf-tiny-scalable.yml
+++ b/templates/tiny/cf-tiny-scalable.yml
@@ -8,7 +8,8 @@ meta:
     ignored_domains: (( merge || [] ))
 
   release:
-    name: cf
+    cf: cf
+    haproxy: cf-haproxy
 
   domain: (( merge ))
   app_domains: (( merge ))
@@ -21,7 +22,8 @@ meta:
     space: (( merge || "smoke-tests" ))
 
   ha_proxy:
-    ssl_pem: (( merge ))
+    <<:(( merge ))
+    backend_servers; (( jobs.router_z2.networks.cf1.static_ips jobs.router_z2.cf2.static_ips ))
   floating_static_ips: (( merge ))
   networks:
     z1:
@@ -37,94 +39,95 @@ meta:
 
   data_templates:
   - name: postgres
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
   - name: debian_nfs_server
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
   - name: metron_agent
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
   - name: consul_agent
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
 
   backbone_templates:
   - name: nats
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
   - name: nats_stream_forwarder
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
   - name: doppler
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
   - name: syslog_drain_binder
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
   - name: metron_agent
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
   - name: consul_agent
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
 
   ha_proxy_templates:
   - name: metron_agent
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
   - name: haproxy
-    release: (( meta.release.name ))
+    release: (( meta.release.haproxy ))
   - name: consul_agent
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
 
   api_templates:
   - name: routing-api
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
   - name: gorouter
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
   - name: cloud_controller_ng
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
   - name: metron_agent
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
   - name: nfs_mounter
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
   - name: consul_agent
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
 
   services_templates:
   - name: uaa
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
   - name: cloud_controller_worker
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
   - name: etcd
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
   - name: etcd_metrics_server
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
   - name: metron_agent
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
   - name: nfs_mounter
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
   - name: consul_agent
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
 
   dea_templates:
   - name: dea_next
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
   - name: dea_logging_agent
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
   - name: metron_agent
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
   - name: consul_agent
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
 
   health_templates:
   - name: loggregator_trafficcontroller
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
   - name: hm9000
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
   - name: cloud_controller_clock
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
   - name: metron_agent
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
   - name: collector
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
   - name: consul_agent
-    release: (( meta.release.name ))
+    release: (( meta.release.cf ))
 
   instances:
     backbone_z1:             (( merge || 1 ))
     backbone_z2:             (( merge || 0 ))
-    haproxy_z1:              (( merge || 1 ))
+    public_haproxy_z1:       (( merge || 1 ))
+    private_haproxy_z1:      (( merge || 0 ))
     api_z1:                  (( merge || 1 ))
     api_z2:                  (( merge || 0 ))
     services_z1:             (( merge || 1 ))
@@ -306,10 +309,11 @@ jobs:
         https_proxy: (( meta.proxy.https_server ))
         no_proxy: (( meta.proxy.ignored_domains ))
 
-  - name: haproxy_z1
-    instances: (( meta.instances.haproxy_z1 ))
+  - name: public_haproxy_z1
+    instances: (( meta.instances.public_haproxy_z1 ))
     templates: (( meta.ha_proxy_templates ))
     resource_pool: small_z1
+    persistent_disk: 0
     networks:
       - name: floating
         static_ips: (( meta.floating_static_ips ))
@@ -319,8 +323,22 @@ jobs:
     properties:
       <<: (( merge ))
       networks: (( meta.networks.z1 ))
+      metron_agent:
+        zone: z1
+  - name: private_haproxy_z1
+    instances: (( meta.instances.private_haproxy_z1 ))
+    templates: (( meta.ha_proxy_templates ))
+    resource_pool: small_z1
+    persistent_disk: 0
+    networks:
+      - name: lb1
+        default: [dns, gateway]
+        static_ips: (( static_ips(0, 11, 12, 13, 14, 15) ))
+    properties:
+      <<: (( merge ))
+      networks: (( meta.networks.z1 ))
       ha_proxy:
-        ssl_pem: (( meta.ha_proxy.ssl_pem ))
+        internal_only_domains: []
       metron_agent:
         zone: z1
 
@@ -399,6 +417,8 @@ properties:
   disk_quota_enabled: true
 
   request_timeout_in_seconds: 900
+
+  ha_proxy: (( meta.ha_proxy || {} ))
 
   ccdb:
     address: (( jobs.data.networks.cf1.static_ips.[0] ))

--- a/templates/tiny/cf-tiny-scalable.yml
+++ b/templates/tiny/cf-tiny-scalable.yml
@@ -21,9 +21,7 @@ meta:
     org: (( merge || "smoke-tests" ))
     space: (( merge || "smoke-tests" ))
 
-  ha_proxy:
-    <<:(( merge ))
-    backend_servers; (( jobs.router_z2.networks.cf1.static_ips jobs.router_z2.cf2.static_ips ))
+  ha_proxy: (( merge ))
   floating_static_ips: (( merge ))
   networks:
     z1:
@@ -418,7 +416,9 @@ properties:
 
   request_timeout_in_seconds: 900
 
-  ha_proxy: (( meta.ha_proxy || {} ))
+  ha_proxy:
+    <<: (( merge ))
+    backend_servers: (( jobs.api_z1.networks.cf1.static_ips jobs.api_z2.networks.cf2.static_ips ))
 
   ccdb:
     address: (( jobs.data.networks.cf1.static_ips.[0] ))

--- a/templates/tiny/cf-tiny-scalable.yml
+++ b/templates/tiny/cf-tiny-scalable.yml
@@ -333,7 +333,7 @@ jobs:
     networks:
       - name: lb1
         default: [dns, gateway]
-        static_ips: (( static_ips(0, 11, 12, 13, 14, 15) ))
+        static_ips: (( static_ips(31, 32, 33, 34, 35, 36) ))
     properties:
       <<: (( merge ))
       networks: (( meta.networks.z1 ))

--- a/templates/tiny/cf-use-haproxy.yml
+++ b/templates/tiny/cf-use-haproxy.yml
@@ -17,6 +17,7 @@ meta:
 
   floating_static_ips: (( merge ))
   ha_proxy:
+    <<: (( merge ))
     ssl_pem: (( merge || defaults.ha_proxy.ssl_pem ))
 
 resource_pools:
@@ -51,6 +52,11 @@ properties:
   login:
     # Certificate to import if the UAA is using self-signed certificates
     uaa_certificate: (( meta.ha_proxy.ssl_pem ))
+
+  logger_endpoint:
+    port: 443
+
+  ha_proxy: (( meta.ha_proxy ))
 
 defaults:
   lb1:


### PR DESCRIPTION
Default to using the cf-haproxy-boshrelease for haproxy, one public haproxy, one private haproxy.

Reworked templates to allow deployment file's meta.ha_proxy to customize ha_proxy settings as needed (while still preserving that the private haproxy shouldn't block anything)