### PR TITLE
Add syslog_drain_binder template to cf-tiny-dev

### DIFF
--- a/templates/tiny/cf-tiny-dev.yml
+++ b/templates/tiny/cf-tiny-dev.yml
@@ -44,6 +44,8 @@ meta:
     release: (( meta.release.name ))
   - name: metron_agent
     release: (( meta.release.name ))
+  - name: syslog_drain_binder
+    release: (( meta.release.name ))
 
   ha_proxy_templates:
   - name: metron_agent


### PR DESCRIPTION
The `cf-tiny-dev` release is missing the `syslog_drain_binder` template, which this fixes.