### PR TITLE
(amend) Reworked additional security group rules supplemental services

### DIFF
--- a/deployments/cf-aws-large-consul.yml
+++ b/deployments/cf-aws-large-consul.yml
@@ -48,6 +48,7 @@ meta:
   zones:
     z1: CF_SUBNET1_AZ
     z2: CF_SUBNET2_AZ
+  additional_security_group_rules: [] # if you have any additional security group rules, add here
   allowed_services_network_range:
     - 10.10.5.0 - 10.255.255.255
   floating_static_ips:

--- a/deployments/cf-aws-large.yml
+++ b/deployments/cf-aws-large.yml
@@ -40,6 +40,7 @@ meta:
   zones:
     z1: CF_SUBNET1_AZ
     z2: CF_SUBNET2_AZ
+  additional_security_group_rules: [] # if you have any additional security group rules, add here
   allowed_services_network_range: 10.10.5.0 - 10.255.255.255
   floating_static_ips:
     - CF_ELASTIC_IP

--- a/deployments/cf-aws-tiny-consul.yml
+++ b/deployments/cf-aws-tiny-consul.yml
@@ -43,6 +43,7 @@ meta:
   zones:
     z1: CF_SUBNET1_AZ
     z2: CF_SUBNET2_AZ
+  additional_security_group_rules: [] # if you have any additional security group rules, add here
   allowed_services_network_range:
     - 10.10.5.0 - 10.255.255.255
   floating_static_ips:


### PR DESCRIPTION
also added these changes to {cf-aws-large-consul.yml, cf-aws-large.yml, cf-aws-tiny-consul.yml} to make them work again.

applied the changes from @geofffranks also to the other templates, inspired by this commit:
https://github.com/cloudfoundry-community/cf-boshworkspace/commit/6775da6a6436334074b5c1296fbcccd030090998