### PR TITLE
Fixes issue: Error 100: Error filling in template `haproxy.conf.erb' for `ha_proxy_z1/0' (line 28: Can't find property `["ha_proxy.ssl_pem"]')

### DIFF
--- a/templates/cf-use-haproxy.yml
+++ b/templates/cf-use-haproxy.yml
@@ -52,6 +52,8 @@ jobs:
     properties:
       networks:
         apps: lb1
+      ha_proxy:
+            ssl_pem: (( meta.ha_proxy_ssl_pem ))
 
 resource_pools:
   - name: router_z1


### PR DESCRIPTION
Fixes issue:

Started preparing configuration > Binding configuration. Failed: Error
filling in template `haproxy.conf.erb' for `ha_proxy_z1/0' (line 28:
Can't find property `["ha_proxy.ssl_pem"]') (00:00:00)

Error 100: Error filling in template `haproxy.conf.erb' for
`ha_proxy_z1/0' (line 28: Can't find property `["ha_proxy.ssl_pem"]')