### PR TITLE
Fix tiny scalable job order

### DIFF
--- a/templates/tiny/cf-tiny-scalable.yml
+++ b/templates/tiny/cf-tiny-scalable.yml
@@ -36,10 +36,6 @@ meta:
       - (( .networks.cf2.subnets.[0].range || nil ))
 
   data_templates:
-  - name: etcd
-    release: (( meta.release.cf ))
-  - name: etcd_metrics_server
-    release: (( meta.release.cf ))
   - name: postgres
     release: (( meta.release.cf ))
   - name: debian_nfs_server
@@ -50,6 +46,10 @@ meta:
     release: (( meta.release.cf ))
 
   backbone_templates:
+  - name: etcd
+    release: (( meta.release.cf ))
+  - name: etcd_metrics_server
+    release: (( meta.release.cf ))
   - name: nats
     release: (( meta.release.cf ))
   - name: nats_stream_forwarder
@@ -89,10 +89,6 @@ meta:
   - name: uaa
     release: (( meta.release.cf ))
   - name: cloud_controller_worker
-    release: (( meta.release.cf ))
-  - name: etcd
-    release: (( meta.release.cf ))
-  - name: etcd_metrics_server
     release: (( meta.release.cf ))
   - name: metron_agent
     release: (( meta.release.cf ))
@@ -483,7 +479,7 @@ properties:
     prof_port: 0
 
   etcd:
-    machines: (( jobs.services_z1.networks.cf1.static_ips jobs.services_z2.networks.cf2.static_ips jobs.data.networks.cf1.static_ips ))
+    machines: (( jobs.backbone_z1.networks.cf1.static_ips jobs.backbone_z2.networks.cf2.static_ips ))
 
   etcd_metrics_server:
     nats:

--- a/templates/tiny/cf-tiny-scalable.yml
+++ b/templates/tiny/cf-tiny-scalable.yml
@@ -310,8 +310,6 @@ jobs:
     instances: (( meta.instances.health_z1 ))
     resource_pool: (( meta.job_pools.health "_z1" ))
     templates: (( meta.health_templates ))
-    update:
-      serial: true
     networks:
       - name: cf1
         static_ips: (( static_ips(3, 26, 27, 28, 29, 30) ))
@@ -326,8 +324,6 @@ jobs:
     instances: (( meta.instances.health_z2 ))
     resource_pool: (( meta.job_pools.health "_z2" ))
     templates: (( meta.health_templates ))
-    update:
-      serial: true
     networks:
       - name: cf2
         static_ips: (( static_ips(3, 26, 27, 28, 29, 30) ))
@@ -344,8 +340,6 @@ jobs:
     resource_pool: (( meta.job_pools.services "_z1" ))
     templates: (( meta.services_templates ))
     persistent_disk: 102400
-    update:
-      serial: true
     networks:
       - name: cf1
         static_ips: (( static_ips(2, 21, 22, 23, 24, 25) ))
@@ -359,8 +353,6 @@ jobs:
     resource_pool: (( meta.job_pools.services "_z2" ))
     templates: (( meta.services_templates ))
     persistent_disk: 102400
-    update:
-      serial: true
     networks:
       - name: cf2
         static_ips: (( static_ips(2, 21, 22, 23, 24, 25) ))

--- a/templates/tiny/cf-tiny-scalable.yml
+++ b/templates/tiny/cf-tiny-scalable.yml
@@ -36,6 +36,10 @@ meta:
       - (( .networks.cf2.subnets.[0].range || nil ))
 
   data_templates:
+  - name: etcd
+    release: (( meta.release.cf ))
+  - name: etcd_metrics_server
+    release: (( meta.release.cf ))
   - name: postgres
     release: (( meta.release.cf ))
   - name: debian_nfs_server
@@ -481,7 +485,7 @@ properties:
     prof_port: 0
 
   etcd:
-    machines: (( jobs.services_z1.networks.cf1.static_ips jobs.services_z2.networks.cf2.static_ips ))
+    machines: (( jobs.services_z1.networks.cf1.static_ips jobs.services_z2.networks.cf2.static_ips jobs.data.networks.cf1.static_ips ))
 
   etcd_metrics_server:
     nats:

--- a/templates/tiny/cf-tiny-scalable.yml
+++ b/templates/tiny/cf-tiny-scalable.yml
@@ -150,13 +150,25 @@ meta:
     runner:          (( merge || "runner" ))
 
 jobs:
+  - name: data
+    instances: 1
+    resource_pool: (( meta.job_pools.data "_z1" ))
+    persistent_disk: 102400
+    templates: (( meta.data_templates ))
+    networks:
+      - name: cf1
+        static_ips: (( static_ips(4) ))
+    properties:
+      <<: (( merge ))
+      networks: (( meta.networks.z1 ))
+      metron_agent:
+        zone: z1
+
   - name: backbone_z1
     instances: (( meta.instances.backbone_z1 ))
     persistent_disk: 102400
     templates: (( meta.backbone_templates ))
     resource_pool: (( meta.job_pools.backbone "_z1" ))
-    update:
-      serial: true
     networks:
       - name: cf1
         static_ips: (( static_ips(5, 6, 7, 8, 9, 10) ))
@@ -177,8 +189,6 @@ jobs:
     persistent_disk: 102400
     templates: (( meta.backbone_templates ))
     resource_pool: (( meta.job_pools.backbone "_z2" ))
-    update:
-      serial: true
     networks:
       - name: cf2
         static_ips: (( static_ips(5, 6, 7, 8, 9, 10) ))
@@ -226,17 +236,34 @@ jobs:
       metron_agent:
         zone: z2
 
-  - name: data
-    instances: 1
-    resource_pool: (( meta.job_pools.data "_z1" ))
-    persistent_disk: 102400
-    templates: (( meta.data_templates ))
+  - name: public_haproxy_z1
+    instances: (( meta.instances.public_haproxy_z1 ))
+    resource_pool: (( meta.job_pools.public_haproxy "_z1" ))
+    templates: (( meta.ha_proxy_templates ))
     networks:
-      - name: cf1
-        static_ips: (( static_ips(4) ))
+      - name: floating
+        static_ips: (( meta.floating_static_ips ))
+      - name: lb1
+        default: [dns, gateway]
+        static_ips: (( static_ips(0, 11, 12, 13, 14, 15) ))
     properties:
       <<: (( merge ))
       networks: (( meta.networks.z1 ))
+      metron_agent:
+        zone: z1
+  - name: private_haproxy_z1
+    instances: (( meta.instances.private_haproxy_z1 ))
+    resource_pool: (( meta.job_pools.private_haproxy "_z1" ))
+    templates: (( meta.ha_proxy_templates ))
+    networks:
+      - name: lb1
+        default: [dns, gateway]
+        static_ips: (( static_ips(31, 32, 33, 34, 35, 36) ))
+    properties:
+      <<: (( merge ))
+      networks: (( meta.networks.z1 ))
+      ha_proxy:
+        internal_only_domains: []
       metron_agent:
         zone: z1
 
@@ -283,6 +310,39 @@ jobs:
       metron_agent:
         zone: z2
 
+  - name: health_z1
+    instances: (( meta.instances.health_z1 ))
+    resource_pool: (( meta.job_pools.health "_z1" ))
+    templates: (( meta.health_templates ))
+    update:
+      serial: true
+    networks:
+      - name: cf1
+        static_ips: (( static_ips(3, 26, 27, 28, 29, 30) ))
+    properties:
+      <<: (( merge ))
+      networks: (( meta.networks.z1 ))
+      traffic_controller:
+        zone: z1
+      metron_agent:
+        zone: z1
+  - name: health_z2
+    instances: (( meta.instances.health_z2 ))
+    resource_pool: (( meta.job_pools.health "_z2" ))
+    templates: (( meta.health_templates ))
+    update:
+      serial: true
+    networks:
+      - name: cf2
+        static_ips: (( static_ips(3, 26, 27, 28, 29, 30) ))
+    properties:
+      <<: (( merge ))
+      networks: (( meta.networks.z2 ))
+      traffic_controller:
+        zone: z2
+      metron_agent:
+        zone: z2
+
   - name: services_z1
     instances: (( meta.instances.services_z1 ))
     resource_pool: (( meta.job_pools.services "_z1" ))
@@ -311,68 +371,6 @@ jobs:
     properties:
       <<: (( merge ))
       networks: (( meta.networks.z2 ))
-      metron_agent:
-        zone: z2
-
-  - name: public_haproxy_z1
-    instances: (( meta.instances.public_haproxy_z1 ))
-    resource_pool: (( meta.job_pools.public_haproxy "_z1" ))
-    templates: (( meta.ha_proxy_templates ))
-    persistent_disk: 0
-    networks:
-      - name: floating
-        static_ips: (( meta.floating_static_ips ))
-      - name: lb1
-        default: [dns, gateway]
-        static_ips: (( static_ips(0, 11, 12, 13, 14, 15) ))
-    properties:
-      <<: (( merge ))
-      networks: (( meta.networks.z1 ))
-      metron_agent:
-        zone: z1
-  - name: private_haproxy_z1
-    instances: (( meta.instances.private_haproxy_z1 ))
-    resource_pool: (( meta.job_pools.private_haproxy "_z1" ))
-    templates: (( meta.ha_proxy_templates ))
-    persistent_disk: 0
-    networks:
-      - name: lb1
-        default: [dns, gateway]
-        static_ips: (( static_ips(31, 32, 33, 34, 35, 36) ))
-    properties:
-      <<: (( merge ))
-      networks: (( meta.networks.z1 ))
-      ha_proxy:
-        internal_only_domains: []
-      metron_agent:
-        zone: z1
-
-  - name: health_z1
-    instances: (( meta.instances.health_z1 ))
-    resource_pool: (( meta.job_pools.health "_z1" ))
-    templates: (( meta.health_templates ))
-    networks:
-      - name: cf1
-        static_ips: (( static_ips(3, 26, 27, 28, 29, 30) ))
-    properties:
-      <<: (( merge ))
-      networks: (( meta.networks.z1 ))
-      traffic_controller:
-        zone: z1
-      metron_agent:
-        zone: z1
-  - name: health_z2
-    instances: (( meta.instances.health_z2 ))
-    resource_pool: (( meta.job_pools.health "_z2" ))
-    templates: (( meta.health_templates ))
-    networks:
-      - name: cf2
-        static_ips: (( static_ips(3, 26, 27, 28, 29, 30) ))
-    properties:
-      <<: (( merge ))
-      networks: (( meta.networks.z2 ))
-      traffic_controller:
-        zone: z2
       metron_agent:
         zone: z2
 

--- a/templates/tiny/cf-tiny-scalable.yml
+++ b/templates/tiny/cf-tiny-scalable.yml
@@ -475,7 +475,10 @@ properties:
 
   etcd_metrics_server:
     nats:
-      machines: (( .properties.nats.machines ))
+      # until http://git.io/vsUDx is fixed and included in etcd_metrics_server
+      # point to canary node since it will be updated first
+      machines:
+        - (( .properties.nats.machines.[0] ))
       username: (( .properties.nats.user ))
       password: (( .properties.nats.password ))
 


### PR DESCRIPTION
The routing_api job requires etcd, this was causing failures since the services node (which hosts etcd) is started after the api (includes routing_api job) node.
In this PR etcd is moved to the backbone node.
Also the jobs have been shuffled around so that al nodes that don't depend on other nodes can start at the same time.
After that the api is started (which includes the router)
And as a last step services and health which both depend on the api are started at the same time.