### PR TITLE
Tiny warden

### DIFF
--- a/deployments/cf-aws-tiny.yml
+++ b/deployments/cf-aws-tiny.yml
@@ -18,6 +18,9 @@ templates:
   - cf/cf-properties.yml
   - cf/cf-infrastructure-aws.yml
   - cf-properties.yml
+  - tiny/cf-jobs-nfs.yml
+  - tiny/cf-jobs-login.yml
+  - tiny/cf-jobs-base.yml
   - parallel.yml
   - cf-no-ssl.yml
   - cf-secrets.yml

--- a/deployments/cf-openstack-tiny.yml
+++ b/deployments/cf-openstack-tiny.yml
@@ -23,6 +23,9 @@ templates:
 #  - offline-java-buildpack.yml
   - cf/cf-infrastructure-openstack.yml
   - cf-properties.yml
+  - tiny/cf-jobs-nfs.yml
+  - tiny/cf-jobs-login.yml
+  - tiny/cf-jobs-base.yml
   - parallel.yml
   - cf-no-ssl.yml
   - cf-secrets.yml

--- a/deployments/cf-warden-tiny.yml
+++ b/deployments/cf-warden-tiny.yml
@@ -1,0 +1,32 @@
+name: cf-warden-tiny
+director_uuid: current
+releases:
+- name: cf
+  version: 207
+  git: https://github.com/cloudfoundry/cf-release.git
+- name: cf-haproxy
+  version: 2
+  git: https://github.com/cloudfoundry-community/cf-haproxy-boshrelease.git
+
+
+stemcells:
+- name: bosh-warden-boshlite-ubuntu-trusty-go_agent
+  version: 389
+
+templates:
+- cf/cf-deployment.yml
+- tiny/cf-tiny-scalable.yml
+- cf-uaa-port.yml
+- cf-allow-services-access.yml
+- cf/cf-properties.yml
+- cf/cf-infrastructure-warden.yml
+- cf-properties.yml
+- tiny/cf-infrastructure-warden.yml
+- tiny/cf-jobs-login.yml
+- tiny/cf-jobs-base.yml
+- parallel.yml
+- cf-no-ssl.yml
+- cf-secrets.yml
+
+meta:
+  admin_secret: admin

--- a/templates/tiny/cf-infrastructure-warden.yml
+++ b/templates/tiny/cf-infrastructure-warden.yml
@@ -1,0 +1,139 @@
+meta:
+  instances:
+    public_haproxy_z1: (( merge || 1 ))
+    api_z1: (( merge || 0 ))
+    api_z2: 1 #(( merge || 1 ))
+    backbone_z1: (( merge || 1 ))
+    backbone_z2: (( merge || 0 ))
+  floating_static_ips: []
+  additional_security_group_rules: [] # if you have any additional security group rules, add here
+
+  domain: (( jobs.public_haproxy_z1.networks.lb1.static_ips.[0] ".xip.io" ))
+  app_domains: (( meta.domain ))
+
+  ha_proxy:
+    ssl_pem: (( defaults.ha_proxy.ssl_pem ))
+
+  api_templates: (( merge ))
+
+jobs:
+  - name: public_haproxy_z1
+    instances: (( meta.instances.public_haproxy_z1 ))    
+    networks:
+      - name: lb1
+        static_ips: (( static_ips(0, 11, 12, 13, 14, 15) ))
+        
+  - name: data
+    instances: 1
+    networks:
+      - name: cf1
+        static_ips: (( static_ips(4) ))
+
+  - name: backbone_z1
+    instances: (( meta.instances.backbone_z1 ))
+    networks:
+      - name: cf1
+        static_ips: (( static_ips(5, 6, 7, 8, 9, 10) ))
+        
+  - name: backbone_z2
+    instances: (( meta.instances.backbone_z2 ))
+    networks:
+      - name: cf2
+        static_ips: (( static_ips(5, 6, 7, 8, 9, 10) ))
+
+  - name: api_z1
+    instances: (( meta.instances.api_z1 ))
+    templates: (( meta.api_templates ))
+    
+  - name: api_z2
+    instances: (( meta.instances.api_z2 ))
+    templates: (( meta.api_templates ))
+
+properties:
+  <<: (( merge ))
+  nfs_server:
+    address: ~
+
+  nats:
+    address: (( jobs.backbone_z1.networks.cf1.static_ips.[0] || jobs.backbone_z2.networks.cf2.static_ips.[0] ))
+
+  databases:
+    address: (( jobs.data.networks.cf1.static_ips.[0] ))
+
+
+networks:
+  - name: cf1
+    type: manual
+    subnets:
+      - range: 10.244.2.0/24
+        gateway: 10.244.2.1
+        static:
+          - 10.244.2.2-10.244.2.60
+      
+  - name: cf2
+    type: manual
+    subnets:
+      - range: 10.244.3.0/24
+        gateway: 10.244.3.1
+        static:
+          - 10.244.3.2-10.244.3.60
+
+  - name: lb1
+    type: manual
+    subnets:
+      - range: 10.244.4.0/24
+        gateway: 10.244.4.1
+        static:
+          - 10.244.4.2-10.244.4.60
+
+        
+
+defaults:
+  ha_proxy:
+    ssl_pem: |
+      -----BEGIN CERTIFICATE-----
+      MIIDETCCAfmgAwIBAgIJANZuykf1uh3LMA0GCSqGSIb3DQEBBQUAMB8xHTAbBgNV
+      BAMMFCouMTAuMjQ0LjAuMzQueGlwLmlvMB4XDTE0MTIyNDIzMTkxM1oXDTI0MTIy
+      MTIzMTkxM1owHzEdMBsGA1UEAwwUKi4xMC4yNDQuMC4zNC54aXAuaW8wggEiMA0G
+      CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDCjq73Fgwfj2UT0/+wR9kVVsGAguMj
+      poA0opLCgE0yHStAhSvqq7YpO39dH3vBMWXyr2xIfDyaeZyhV86jWu/ZKswGjNGI
+      ZKv/yUINe1bqukOBqd+SHVvkVhxSLJuD1MR83JQMONRjOPJp661/ABpVhnrNfBiA
+      AA6aaFv4/KbyGY/E1FHoUXqEdh4WxaJdfX6SbgG05ArWxhSD7PNj4CYvJWGCdvqP
+      KBsvWFDrkxBHn5h1JIDfZJB8FKP6vaHBr7MU4pIHM+qaZ1Y+8ja0wcgkHn4YHcp6
+      IOhqpck7LaH5Qq2ydYFNTcG4fTbG0jXqcit2WSUxRkXzWnrgo2E0SiHBAgMBAAGj
+      UDBOMB0GA1UdDgQWBBSpCtEDtEvMwaZzXN6Lvk5U7Eyn2zAfBgNVHSMEGDAWgBSp
+      CtEDtEvMwaZzXN6Lvk5U7Eyn2zAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBBQUA
+      A4IBAQB1YIHmw3gPiMn8WDR4yVxDvSVgFHY6ZE1iZb17vVs4N2/mhQZXWJ2nZV02
+      goAivtgxHOj39sK5OBWsGvrQo5H8dt1t4XmbwB1C6xRerGc25dhDRq42RqhCN0RJ
+      zzjd9b8YSiwtAaZlW36l2jVDLfRapb00tWToF9qYrDrmKy2sekS7g2hbiRStcue/
+      bpT4X/CHxb/lUbpL4m8BpDbkGiOJgl+SEHRx5tZ0Kob/RDQRCcN3p+71FRbDIEBj
+      +8sJl/yUUUPwQ6PNYx6cjtlICWJ1G0l0hRa141VXPqSNCmxYS4dp/8ifPCSoLc+k
+      9TXFkuGl+86CPTyyMJxyMhEcAGZT
+      -----END CERTIFICATE-----
+      -----BEGIN RSA PRIVATE KEY-----
+      MIIEpAIBAAKCAQEAwo6u9xYMH49lE9P/sEfZFVbBgILjI6aANKKSwoBNMh0rQIUr
+      6qu2KTt/XR97wTFl8q9sSHw8mnmcoVfOo1rv2SrMBozRiGSr/8lCDXtW6rpDganf
+      kh1b5FYcUiybg9TEfNyUDDjUYzjyaeutfwAaVYZ6zXwYgAAOmmhb+Pym8hmPxNRR
+      6FF6hHYeFsWiXX1+km4BtOQK1sYUg+zzY+AmLyVhgnb6jygbL1hQ65MQR5+YdSSA
+      32SQfBSj+r2hwa+zFOKSBzPqmmdWPvI2tMHIJB5+GB3KeiDoaqXJOy2h+UKtsnWB
+      TU3BuH02xtI16nIrdlklMUZF81p64KNhNEohwQIDAQABAoIBAC1U3YOIyY5Y9O4n
+      yT2jn/sO2cs9s/rMgrbA4n0bM+FnVnqUDOWC2NDGoihqe4VKIzzmjs5c1CoSB+K3
+      +NerCpOJGzyzdubWvhS9KfzGLjxG5g/CKut6l7yeK78h0aJn4thM9NncK/BqhmET
+      nrsmpPwkd1yFe5fna3+irTtYcvWZgxp8DK4JxIRB0QpJvEwbs9fUFE1E0DVw/uBV
+      CytTIrik2O+n1m8S5xzsFXHXDjXT/TVNi3jtN12Oaj1avYZRP2q45RmcODhtHQIy
+      4o0vqjyAmZb3jOcYysyXVwfyNreIH3Qn0/waflPkyaljMpa1OHVOCJFjh2Xl+aIc
+      dQsME3kCgYEA4aXU2xb9SHew84/3ow6ZmBeYLm+7B8GUjDTe7HqLldtTUhlrJSdB
+      SHZHZ/BXEQ126FnbfZ0IISkBjqVCQBw8MgjZAlaEIInDA1DRTLuOfrcyUD6PeSLi
+      gVZHNYbR9MDnmJ3/So5HXiRy2rBWtLKwPlciqbwY+l3xYr2kP/QdCisCgYEA3LpB
+      TBDTqp9j8QVvB/YjCakS+z+kgtO5HyMZO/uh6o9PRHrFQHwZA5y/MRrx9lxJ9zOd
+      fqysKfA7fXs4VzNnRSnOfBmuDHF0HhlIgAShX/RnB94p9xnsQaMae/o2nXcknQng
+      3qogvHWTo16GCJRE+YTmhA0QtvSlScJlTzHfqcMCgYAPRt/rWVoajufvBX85jeJ+
+      NpK6Chx6gPOirm2tSvqqUagJdekYIdk8o61f7xil8ehsALFohronLJSLaMrcdkzp
+      AkpW6y6U2V7XmaAh9szF7Xc9kY67H85//SxjBlauoGTNo1zGWm2ghQ01mxyzrSlb
+      fyC8pxx1zuhpy/cT0V4p8wKBgQDb+EJaq+pFf9L5v5CHPqRsXDKucR5hwt4aScA8
+      JumV+HvmovMw8Ht9PhjLty6rdg3AbY/nTe3FXcPrqYDcZj3kj2VYB7+MZwRxeoDm
+      E7c/CTIkhSMNPqhUQVeDdjg3dSTn25BeVu2I4yPfC7RHmHukru2La/ncWrLebvzH
+      j8x2QQKBgQDevjRDDTWbBkg8HdCRxxCvhfaHBntoSJdTHlr14Gce48NXGaXRJPQT
+      9dMsPsSHkFxEra7G2clGnhpe+pK9V+WTrD9Qnoc+tK808hX1YQ6mBlnR6w99jlaR
+      HVTi2pRhEhbWUkBv2kooXvD6ANb15PbPSF1FK7YyW1KHqcbm+lF22g==
+      -----END RSA PRIVATE KEY-----

--- a/templates/tiny/cf-jobs-base.yml
+++ b/templates/tiny/cf-jobs-base.yml
@@ -1,0 +1,87 @@
+meta:
+  release:
+    cf: cf
+    haproxy: cf-haproxy
+
+  data_templates:
+    - name: postgres
+      release: (( meta.release.cf ))
+    - name: metron_agent
+      release: (( meta.release.cf ))
+    - name: consul_agent
+      release: (( meta.release.cf ))
+
+  backbone_templates:
+    - name: etcd
+      release: (( meta.release.cf ))
+    - name: etcd_metrics_server
+      release: (( meta.release.cf ))
+    - name: nats
+      release: (( meta.release.cf ))
+    - name: nats_stream_forwarder
+      release: (( meta.release.cf ))
+    - name: doppler
+      release: (( meta.release.cf ))
+    - name: syslog_drain_binder
+      release: (( meta.release.cf ))
+    - name: metron_agent
+      release: (( meta.release.cf ))
+    - name: consul_agent
+      release: (( meta.release.cf ))
+
+  ha_proxy_templates:
+    - name: metron_agent
+      release: (( meta.release.cf ))
+    - name: haproxy
+      release: (( meta.release.haproxy ))
+    - name: consul_agent
+      release: (( meta.release.cf ))
+
+  api_templates:
+    - name: routing-api
+      release: (( meta.release.cf ))
+    - name: gorouter
+      release: (( meta.release.cf ))
+    - name: cloud_controller_ng
+      release: (( meta.release.cf ))
+    - name: metron_agent
+      release: (( meta.release.cf ))
+    - name: consul_agent
+      release: (( meta.release.cf ))
+
+  services_templates:
+    - name: uaa
+      release: (( meta.release.cf ))
+    - name: cloud_controller_worker
+      release: (( meta.release.cf ))
+    - name: metron_agent
+      release: (( meta.release.cf ))
+    - name: consul_agent
+      release: (( meta.release.cf ))
+
+  dea_templates:
+    - name: dea_next
+      release: (( meta.release.cf ))
+    - name: dea_logging_agent
+      release: (( meta.release.cf ))
+    - name: metron_agent
+      release: (( meta.release.cf ))
+    - name: consul_agent
+      release: (( meta.release.cf ))
+
+  health_templates:
+    - name: loggregator_trafficcontroller
+      release: (( meta.release.cf ))
+    - name: hm9000
+      release: (( meta.release.cf ))
+    - name: cloud_controller_clock
+      release: (( meta.release.cf ))
+    - name: metron_agent
+      release: (( meta.release.cf ))
+    - name: collector
+      release: (( meta.release.cf ))
+    - name: consul_agent
+      release: (( meta.release.cf ))
+
+
+

--- a/templates/tiny/cf-jobs-login.yml
+++ b/templates/tiny/cf-jobs-login.yml
@@ -1,0 +1,9 @@
+meta:
+  release:
+    cf: cf
+    
+  services_templates:
+    - <<: (( merge ))
+    - name: login
+      release: (( meta.release.cf ))
+

--- a/templates/tiny/cf-jobs-nfs.yml
+++ b/templates/tiny/cf-jobs-nfs.yml
@@ -14,7 +14,6 @@ meta:
     - name: nfs_mounter
       release: (( meta.release.cf ))
   
-meta:
   release:
     cf: cf
     haproxy: cf-haproxy

--- a/templates/tiny/cf-jobs-nfs.yml
+++ b/templates/tiny/cf-jobs-nfs.yml
@@ -1,0 +1,22 @@
+meta:
+  data_templates:
+    - <<: (( merge ))
+    - name: debian_nfs_server
+      release: (( meta.release.cf ))
+
+  api_templates:
+    - <<: (( merge ))
+    - name: nfs_mounter
+      release: (( meta.release.cf ))
+
+  services:
+    - <<: (( merge ))
+    - name: nfs_mounter
+      release: (( meta.release.cf ))
+  
+meta:
+  release:
+    cf: cf
+    haproxy: cf-haproxy
+
+

--- a/templates/tiny/cf-tiny-scalable.yml
+++ b/templates/tiny/cf-tiny-scalable.yml
@@ -30,96 +30,19 @@ meta:
       apps: cf2
 
   nfs_server:
-    address: (( jobs.data.networks.cf1.static_ips.[0] ))
+    address: (( merge || jobs.data.networks.cf1.static_ips.[0] ))
     allow_from_entries:
       - (( .networks.cf1.subnets.[0].range || nil ))
       - (( .networks.cf2.subnets.[0].range || nil ))
 
-  data_templates:
-  - name: postgres
-    release: (( meta.release.cf ))
-  - name: debian_nfs_server
-    release: (( meta.release.cf ))
-  - name: metron_agent
-    release: (( meta.release.cf ))
-  - name: consul_agent
-    release: (( meta.release.cf ))
-
-  backbone_templates:
-  - name: etcd
-    release: (( meta.release.cf ))
-  - name: etcd_metrics_server
-    release: (( meta.release.cf ))
-  - name: nats
-    release: (( meta.release.cf ))
-  - name: nats_stream_forwarder
-    release: (( meta.release.cf ))
-  - name: doppler
-    release: (( meta.release.cf ))
-  - name: syslog_drain_binder
-    release: (( meta.release.cf ))
-  - name: metron_agent
-    release: (( meta.release.cf ))
-  - name: consul_agent
-    release: (( meta.release.cf ))
-
-  ha_proxy_templates:
-  - name: metron_agent
-    release: (( meta.release.cf ))
-  - name: haproxy
-    release: (( meta.release.haproxy ))
-  - name: consul_agent
-    release: (( meta.release.cf ))
-
-  api_templates:
-  - name: routing-api
-    release: (( meta.release.cf ))
-  - name: gorouter
-    release: (( meta.release.cf ))
-  - name: cloud_controller_ng
-    release: (( meta.release.cf ))
-  - name: metron_agent
-    release: (( meta.release.cf ))
-  - name: nfs_mounter
-    release: (( meta.release.cf ))
-  - name: consul_agent
-    release: (( meta.release.cf ))
-
-  services_templates:
-  - name: uaa
-    release: (( meta.release.cf ))
-  - name: cloud_controller_worker
-    release: (( meta.release.cf ))
-  - name: metron_agent
-    release: (( meta.release.cf ))
-  - name: nfs_mounter
-    release: (( meta.release.cf ))
-  - name: consul_agent
-    release: (( meta.release.cf ))
-
-  dea_templates:
-  - name: dea_next
-    release: (( meta.release.cf ))
-  - name: dea_logging_agent
-    release: (( meta.release.cf ))
-  - name: metron_agent
-    release: (( meta.release.cf ))
-  - name: consul_agent
-    release: (( meta.release.cf ))
-
-  health_templates:
-  - name: loggregator_trafficcontroller
-    release: (( meta.release.cf ))
-  - name: hm9000
-    release: (( meta.release.cf ))
-  - name: cloud_controller_clock
-    release: (( meta.release.cf ))
-  - name: metron_agent
-    release: (( meta.release.cf ))
-  - name: collector
-    release: (( meta.release.cf ))
-  - name: consul_agent
-    release: (( meta.release.cf ))
+  api_templates: (( merge ))
+  backbone_templates: (( merge ))
+  data_templates: (( merge ))
+  dea_templates: (( merge ))
+  ha_proxy_templates: (( merge ))
+  health_templates: (( merge ))
+  release: (( merge ))
+  services_templates: (( merge ))
 
   instances:
     backbone_z1:             (( merge || 1 ))
@@ -236,12 +159,13 @@ jobs:
     instances: (( meta.instances.public_haproxy_z1 ))
     resource_pool: (( meta.job_pools.public_haproxy "_z1" ))
     templates: (( meta.ha_proxy_templates ))
-    networks:
+    default_networks:
       - name: floating
         static_ips: (( meta.floating_static_ips ))
       - name: lb1
         default: [dns, gateway]
         static_ips: (( static_ips(0, 11, 12, 13, 14, 15) ))
+    networks: (( merge || default_networks ))
     properties:
       <<: (( merge ))
       networks: (( meta.networks.z1 ))


### PR DESCRIPTION
Added tiny warden deployment for development on bosh-lite.
Also extracted the job templates into separate files which makes it easier to colocate additional jobs.