### PR TITLE
Increase timeouts allows create service-instance

### DIFF
--- a/templates/tiny/cf-tiny-scalable.yml
+++ b/templates/tiny/cf-tiny-scalable.yml
@@ -386,6 +386,9 @@ properties:
 
   ha_proxy:
     <<: (( merge ))
+    client_timeout: 120
+    server_timeout: 120
+    request_timeout: 120
     backend_servers: (( jobs.api_z1.networks.cf1.static_ips jobs.api_z2.networks.cf2.static_ips ))
 
   ccdb:


### PR DESCRIPTION
requests which can take up to 60 seconds